### PR TITLE
Change the seed argument as optional

### DIFF
--- a/src/classes.d.ts
+++ b/src/classes.d.ts
@@ -67,7 +67,7 @@ interface LuaGameScript {
     disable_tutorial_triggers(this: void): void
     direction_to_string(this: void, direction: defines.direction): void
     print(this: void, message: LocalisedString, color: Color): void
-    create_random_generator(this: void, seed: number): LuaRandomGenerator
+    create_random_generator(this: void, seed?: number): LuaRandomGenerator
     check_prototype_translations(this: void): void
     play_sound(
         this: void,


### PR DESCRIPTION
According to [Factorio API Document](https://lua-api.factorio.com/0.17.68/LuaGameScript.html#LuaGameScript.create_random_generator), the argument named seed for LuaGameScript.create_random_generator is optional.

So I changed seed to seed?.