### PR TITLE
Use generics

### DIFF
--- a/src/classes.d.ts
+++ b/src/classes.d.ts
@@ -225,10 +225,10 @@ interface LuaBootstrap {
     on_init(this: void, f: (() => any | null)): void
     on_load(this: void, f: (() => any | null)): void
     on_configuration_changed(this: void, f: (() => any | null)): void
-    on_event(
+    on_event<T extends event>(
         this: void,
         event: defines.events | defines.events[] | string,
-        callback: (this: void, event: event) => void): void
+        callback: (this: void, event: T) => void): void
     on_nth_tick(this: void, tick: number | number[] | null, f: (event: NthTickEvent) => void): void
     generate_event_name(this: void): number
     get_event_handler(this: void, event: number): () => any


### PR DESCRIPTION
When I use on_event method, the error on the difference between event and some event extends event was occurred.

I think it is better to use generics.